### PR TITLE
Update .textlintrc configuration for better plugin compatibility

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -1,4 +1,8 @@
 {
+    "plugins": ["latex2e", "html"],
+    "filters": {
+        "comments": true
+    },
     "rules": {
         "preset-ja-technical-writing": {
             "max-kanji-continuous-len": {
@@ -77,9 +81,7 @@
     "overrides": [
         {
             "files": ["*.html"],
-            "plugins": ["html"],
             "filters": {
-                "comments": true,
                 "allowlist": {
                     "allow": [
                         "/<!--[\\s\\S]*?-->/m",
@@ -106,9 +108,7 @@
         },
         {
             "files": ["*.tex", "*.latex"],
-            "plugins": ["latex2e"],
             "filters": {
-                "comments": true,
                 "allowlist": {
                     "allow": [
                         "/%[\\s\\S]*?$/m"


### PR DESCRIPTION
## Summary
- Move plugins to global scope for better compatibility
- Apply plugins (latex2e, html) globally instead of per-override section
- Add global comments filter
- Maintain consistent textlint configuration across templates

## Changes
- Moved `plugins` array from override sections to global scope
- Added global `comments` filter to apply to all file types
- Removed duplicate `comments` filter from override sections
- Plugins now apply to all files, with override rules maintained for specific file types
- Improves plugin compatibility and reduces configuration complexity

## Test plan
- [ ] Verify textlint works correctly with .tex files
- [ ] Verify textlint works correctly with .html files  
- [ ] Check that all existing rules still apply correctly
- [ ] Verify comment filtering works globally