### PR TITLE
Fix update-review-branch workflow: create label before PR creation

### DIFF
--- a/.github/workflows/update-review-branch.yml
+++ b/.github/workflows/update-review-branch.yml
@@ -100,14 +100,17 @@ jobs:
 
           if [ "$PR_EXISTS" -eq 0 ]; then
             echo "Creating review PR"
+            
+            # ラベルを先に作成
+            gh label create "do-not-merge" --color "d73a4a" --description "このPRはマージしないでください" || true
+            
+            # PRを作成
             gh pr create \
               --base initial \
               --head review-branch \
               --title "【レビュー用】レポート全体へのコメント" \
               --label "do-not-merge" \
               --body "このPRはレポート全体への添削コメント用です。詳細は作成後に確認してください。"
-
-            gh label create "do-not-merge" --color "d73a4a" --description "このPRはマージしないでください" || true
 
           else
             echo "Review PR already exists, it has been updated automatically"


### PR DESCRIPTION
This fixes the error where PR creation with --label fails when the label doesn't exist yet.

## Changes
- Move `gh label create` before `gh pr create`
- Add comments for clarity

## Problem Solved
- Eliminates Update Review Branch workflow failures
- Ensures proper label creation order
- Improves reliability for student repository workflows

This change affects all future student repositories created from this template.