### PR TITLE
Fix orphan branch merge issue in update-review-branch workflow

### DIFF
--- a/.github/workflows/update-review-branch.yml
+++ b/.github/workflows/update-review-branch.yml
@@ -62,7 +62,7 @@ jobs:
           # Merge main branch content to include student work
           if git show-ref --verify --quiet refs/remotes/origin/main; then
             echo "Merging main branch content into review-branch"
-            if ! git merge origin/main --no-edit -m "Include main branch content for review"; then
+            if ! git merge origin/main --no-edit --allow-unrelated-histories -m "Include main branch content for review"; then
               echo "⚠️ Failed to merge main branch. Proceeding with empty commit."
               git merge --abort || true
               git commit --allow-empty -m "Initial review branch for report comments (merge failed)"


### PR DESCRIPTION
## 問題

thesis-management-tools で setup.sh 実行時に orphan branch merge エラーが発生しています。同様の問題がこのワークフローでも発生する可能性があります。

## 根本原因

1. initial ブランチが orphan として作成される
2. review-branch が initial から分岐する
3. main ブランチを review-branch にマージする際、共通祖先がないためエラー

## 解決方法

`--allow-unrelated-histories` フラグを追加：

```bash
git merge origin/main --no-edit --allow-unrelated-histories
```

## 関連 PR

- thesis-management-tools #252: main-ise.sh の同様の修正