### PR TITLE
Fix workflow trigger to support all branches for draft-to-draft PRs

### DIFF
--- a/.github/workflows/update-review-branch.yml
+++ b/.github/workflows/update-review-branch.yml
@@ -4,8 +4,6 @@ name: Update Review Branch
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- ワークフローの `branches: - main` 制限を削除
- 全ブランチ対象のPRでreview-branch自動更新を有効化
- `0th-draft` → `1st-draft` PRでワークフローが動かない問題を修正

## Changes Made
- `.github/workflows/update-review-branch.yml` のトリガー条件修正
- `branches:` セクションを削除してすべてのPRを対象に変更

## Reason for Change
実際の学生の使用パターンでは：
- ドラフト間PR（`0th-draft` → `1st-draft` → `2nd-draft`）が主要用途
- main ブランチは最終版のみ使用
- 現在の main 限定では実用的でない

## Test Plan
- [x] k18rs509-ise-report1 リポジトリで動作確認
- [x] 既存のPR #2（`0th-draft` → `1st-draft`）に適用テスト予定

Resolves #44