### PR TITLE
Remove branches filter from prevent-draft-merge workflow

### DIFF
--- a/.github/workflows/prevent-draft-merge.yml
+++ b/.github/workflows/prevent-draft-merge.yml
@@ -4,9 +4,8 @@ name: Prevent Draft Merge
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
-      - review-branch
+    # All draft PRs should be protected, not just PRs to main/review-branch
+    # The reusable workflow checks if the head branch is a draft pattern
 
 jobs:
   prevent-merge:


### PR DESCRIPTION
## Summary
- `branches:` フィルターを削除し、すべての PR で workflow が実行されるように変更
- draft ブランチ間の PR（例: `2nd-draft → 1st-draft`）も保護対象に

## Background
sotsuron-template と同様の修正。reusable workflow 側で head ブランチが draft パターンかどうかをチェックするため、呼び出し側でフィルタリングする必要がない。

## Test plan
- [x] sotsuron-template で同様の修正が正常に動作していることを確認済み