### PR TITLE
Add .gitignore for local settings and editor artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Node.js (textlint / html validation tooling in devcontainer)
+node_modules/
+
+# Claude Code local settings
+.claude/settings.local.json
+
+# Editor backup / swap files
+*~
+*.swp
+[._]*.sw[a-p]
+
+# macOS
+.DS_Store
+
+# Note: index.html / sample-index.html / style.css are tracked source files,
+# so HTML/CSS are intentionally NOT ignored here.


### PR DESCRIPTION
resolve #82

6テンプレート中、本リポジトリだけ `.gitignore` が無く、`node_modules/`（devcontainer の textlint/HTML 検証ツール）・`.claude/settings.local.json`・エディタ/OS 一時ファイルが誤コミットされ得る状態でした。`.gitignore` を新規追加します。

対象:
- `node_modules/`
- `.claude/settings.local.json`
- エディタのバックアップ/スワップ（`*~`, `*.swp` 等）
- `.DS_Store`

**`*.html` は無視しません** — 本テンプレートは `index.html` / `sample-index.html` / `style.css` が追跡対象のソースのため（その旨をファイル末尾コメントにも明記）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)