### PR TITLE
chore: update thesis-management-tools references → student-repo-management

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 1. **Docker Desktop** - 開発環境の実行に必要
 2. **GitHub Desktop** - リポジトリ管理・同期に必要
 3. **GitHub CLI (gh)** - リポジトリ作成スクリプトの実行に必要
-   - [インストール方法](https://github.com/smkwlab/thesis-management-tools/blob/main/docs/INSTALL-GH.md)
+   - [インストール方法](https://github.com/smkwlab/student-repo-management/blob/main/docs/INSTALL-GH.md)
 
 **準備:**
 
@@ -61,12 +61,12 @@ GitHub CLI の認証を完了してください：
 gh auth login
 ```
 
-**注意:** `gh` コマンドが見つからない場合は [インストール方法](https://github.com/smkwlab/thesis-management-tools/blob/main/docs/INSTALL-GH.md) を参照してください。
+**注意:** `gh` コマンドが見つからない場合は [インストール方法](https://github.com/smkwlab/student-repo-management/blob/main/docs/INSTALL-GH.md) を参照してください。
 
 **リポジトリ作成:**
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/thesis-management-tools/v1/create-repo/setup.sh)" bash ise
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)" bash ise
 ```
 
 > 💡 `v1` は安定版（最新の v1 系）を指す移動タグです。最新の開発版を試す場合は URL の `v1` を `main` に置き換えてください。

--- a/docs/CLAUDE-DEVELOPMENT.md
+++ b/docs/CLAUDE-DEVELOPMENT.md
@@ -51,7 +51,7 @@ Part of the broader LaTeX thesis environment ecosystem:
 - **latex-environment**: Provides underlying DevContainer infrastructure
 - **texlive-ja-textlint**: Docker base image for textlint functionality
 - **ai-academic-paper-reviewer**: AI-powered review capabilities (optional)
-- **thesis-management-tools**: Administrative workflow support
+- **student-repo-management**: Administrative workflow support
 
 ### Template Relationship
 ```


### PR DESCRIPTION
## 概要

リポジトリ改名 smkwlab/student-repo-management#504（旧 `thesis-management-tools`）に伴う参照追随。README / docs の `setup.sh` 配布 URL・INSTALL-GH リンク・相互参照を更新。

## 補足

GitHub のリネームリダイレクトで旧 URL は当面生存するが、リダイレクト依存を減らす方針（#504）に沿って能動的に更新。

Refs smkwlab/student-repo-management#504