### PR TITLE
feat: auto-sync accepted suggestions into the next draft branch

### DIFF
--- a/.github/workflows/sync-next-draft.yml
+++ b/.github/workflows/sync-next-draft.yml
@@ -1,0 +1,14 @@
+name: Sync Suggestions to Next Draft
+
+on:
+  push:
+    branches:
+      - '*-draft'
+      - 'abstract-*'
+
+jobs:
+  sync:
+    permissions:
+      contents: write        # 次稿ブランチへの merge push に必要
+      pull-requests: write   # コンフリクト時の同期 PR 作成に必要
+    uses: smkwlab/.github/.github/workflows/sync-next-draft.yml@v1


### PR DESCRIPTION
## 概要

レビュー PR で受け入れた suggestion が次稿ブランチに反映されない問題 (smkwlab/sotsuron-template#110) を自動化で解決します。

## 変更内容

- **新規 `.github/workflows/sync-next-draft.yml`**: draft ブランチへの push をトリガーに、再利用ワークフロー `smkwlab/.github/.github/workflows/sync-next-draft.yml@v1` (v1.25.1) を呼び出す caller。suggestion 受け入れなどの push が後続 draft ブランチへ連鎖的に自動 merge される。コンフリクト時は前稿→次稿の同期 PR が自動作成され、ブラウザの「Resolve conflicts」で解決できる

## 備考

`push` トリガーは push されたブランチ上のワークフローファイルを参照するため、このテンプレート更新は**以降に作成される新規リポジトリ**に有効。既存の k24rs*-ise-report1 リポジトリへは別途一括配布する (default branch + 既存 draft ブランチ)。

Refs: smkwlab/sotsuron-template#110