### PR TITLE
docs: use short URL for repo creation one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ gh auth login
 **リポジトリ作成:**
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)" bash ise
+bash <(curl -fsSL https://repo-setup.smkwlab.net) ise
 ```
 
-> 💡 `v1` は安定版（最新の v1 系）を指す移動タグです。最新の開発版を試す場合は URL の `v1` を `main` に置き換えてください。
+> 💡 短縮 URL `https://repo-setup.smkwlab.net` は安定版（最新の v1 系）の `setup.sh` を配信します。末尾の `ise` が文書タイプとして渡されます。最新の開発版を試す場合は `https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh` を使ってください。
 
 **実行手順:**
 1. 上記コマンドを実行（macOS のターミナルまたは Windows の WSL 内）

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ gh auth login
 bash <(curl -fsSL https://repo-setup.smkwlab.net) ise
 ```
 
-> 💡 短縮 URL `https://repo-setup.smkwlab.net` は安定版（最新の v1 系）の `setup.sh` を配信します。末尾の `ise` が文書タイプとして渡されます。最新の開発版を試す場合は `https://raw.githubusercontent.com/smkwlab/student-repo-management/main/create-repo/setup.sh` を使ってください。
+> 💡 短縮 URL `https://repo-setup.smkwlab.net` は安定版（最新の v1 系）の `setup.sh` を配信します。末尾の `ise` が文書タイプとして渡されます。
 
 **実行手順:**
 1. 上記コマンドを実行（macOS のターミナルまたは Windows の WSL 内）


### PR DESCRIPTION
## 概要

学生に案内するリポジトリ作成コマンドを、長い raw GitHub URL から短縮 URL `https://repo-setup.smkwlab.net` に統一する。student-repo-management / latex-ecosystem で完了済みの方針に合わせるもの。

## 変更内容

- `README.md` のワンライナーをプロセス置換形式に置換（文書タイプ引数 `ise` を保持）
  - Before: `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/smkwlab/student-repo-management/v1/create-repo/setup.sh)" bash ise`
  - After: `bash <(curl -fsSL https://repo-setup.smkwlab.net) ise`
- 併記の注記を短縮 URL の実態に合わせて更新（安定版 v1 系を配信する旨・末尾 `ise` が文書タイプとして渡される旨・開発版を試す場合の raw main URL）
- 旧注記にあった「URL の `v1` を `main` に置き換える」案内は、短縮 URL に `v1` が含まれなくなったため raw main URL の提示に書き換え
