### PR TITLE
docs: link the ecosystem student-workflow guide from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@
 - **透明性**: すべての変更履歴・コメントが記録
 - **効率性**: VS Codeでのリアルタイムフィードバック
 
+> この draft PR サイクル（PR はマージせずクローズ・次稿ブランチ自動作成などの共通ルール）の全体像は
+> [STUDENT-WORKFLOW.md](https://github.com/smkwlab/latex-ecosystem/blob/main/docs/STUDENT-WORKFLOW.md)
+> にまとまっています。本 README は情報科学演習レポート固有の手順を説明します。
+
 ## 2. 具体的な作業内容
 
 ### 2.1 自分用のリモートリポジトリの作成


### PR DESCRIPTION
## 概要

latex-ecosystem のドキュメント再編 Phase 3(smkwlab/latex-ecosystem#134)の対となる変更。エコシステム共通の学生向けガイド [STUDENT-WORKFLOW.md](https://github.com/smkwlab/latex-ecosystem/blob/main/docs/STUDENT-WORKFLOW.md) への逆リンクを README に追加する。

## 変更内容

「提出フローの特徴」の直後に、draft PR サイクルの共通ルール(PR はマージせずクローズ、次稿ブランチ自動作成など)は STUDENT-WORKFLOW.md にまとまっている旨の案内を1つ追加。役割分担(共通ルール = STUDENT-WORKFLOW / ISE 固有の手順 = 本 README)も明示した。

## 背景

STUDENT-WORKFLOW.md 側は #134 で「draft PR サイクルの対象は sotsuron-template と ise-report-template」と明確化され、個別ガイドの例示に本テンプレートの README が追加された。sotsuron-template の README は既に同ガイドへリンクしており、draft サイクルを持つもう一方のテンプレートとして対称にする(wr / latex / poster は draft サイクルを持たないためリンクは追加しない)。
