### PR TITLE
docs: separate the README section from the preceding text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ ise-report-template (HTML specialization)
 - **[Troubleshooting](docs/CLAUDE-TROUBLESHOOTING.md)** - Common issues, debug commands, performance optimization
 
 The student-facing submission flow is documented in the [template README](.github/README.md).
+
 ## Which README is shown where
 
 GitHub resolves READMEs in the order `.github/` -> root -> `docs/`, and


### PR DESCRIPTION
## 概要

`CLAUDE.md` の「Which README is shown where」節が、直前の文と空行なしで続いていたのを修正します。

## 背景

#91 でこの節を追記した際、ファイル末尾に改行がなかったため見出しが前の行に密着していました。Markdown としては見出しとして描画されますが、`poster-template` では空行が入っており、テンプレート間で揃っていませんでした。

```diff
 The student-facing submission flow is documented in the [template README](.github/README.md).
+
 ## Which README is shown where
```

`wr-template` / `latex-template` にも同じ修正を入れています。
