### PR TITLE
ci: update notify-ml-on-pr caller

### DIFF
--- a/.github/workflows/notify-ml-on-pr.yml
+++ b/.github/workflows/notify-ml-on-pr.yml
@@ -1,4 +1,8 @@
----
+# Caller template: Notify Lab ML on PR — calls the notify-ml-on-pr reusable.
+# Distributed by scripts/distribute-workflow.sh as
+# .github/workflows/notify-ml-on-pr.yml in each target repository.
+# secrets: inherit passes the notification secrets the reusable reads; see
+# notify-ml-on-pr.pr-note.md for what must exist at org level.
 name: Notify Lab ML on PR
 
 on:
@@ -8,4 +12,7 @@ on:
 jobs:
   notify:
     uses: smkwlab/.github/.github/workflows/notify-ml-on-pr.yml@v1
+    permissions:
+      contents: read
+      pull-requests: read
     secrets: inherit


### PR DESCRIPTION
Updates the shared `notify-ml-on-pr` workflow as a caller of `smkwlab/.github/.github/workflows/notify-ml-on-pr.yml@v1`.

この caller は `secrets: inherit` で SMTP 系の organization secrets を reusable へ渡します。次の 6 つが org（または対象リポジトリ）に設定されている必要があります:

`SMTP_SERVER` / `SMTP_PORT` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `LAB_ML_ADDRESS` / `SMTP_FROM`

未設定の場合、通知ジョブは実行時に失敗します（caller の設置自体は成功します）。