### PR TITLE
build(devcontainer): align the image with the rest of the ecosystem

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.0
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 ENV PATH=/npm/node_modules/.bin:$PATH
 RUN apk --no-cache add \
@@ -9,7 +9,7 @@ RUN apk --no-cache add \
 
 WORKDIR /npm
 COPY ["package.json", "package-lock.json", "/npm"]
-RUN npm install /npm
+RUN npm ci
 
 WORKDIR /workdir
 


### PR DESCRIPTION
## 概要

この devcontainer は `texlive-ja-textlint` のイメージを使わず自前でビルドしているため、エコシステムの他の場所から取り残されていた。3 点まとめて揃える。

```diff
-FROM alpine:3.22.0
+FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b

-RUN npm install /npm
+RUN npm ci
```

## 1. Node 24 へ

エコシステム内で textlint が動く場所の Node を調べたところ、ここだけが 22 だった。

| 場所 | Node |
|---|---|
| texlive-ja-textlint（debian） | 24（`node:24-trixie-slim`） |
| texlive-ja-textlint（alpine） | 24.18.1（alpine 3.24.1） |
| `smkwlab/.github` の `html-validation.yml` | 24 |
| ai-academic-paper-reviewer | 24（smkwlab/ai-academic-paper-reviewer#64） |
| **この devcontainer** | **22.23.2**（alpine 3.22.0） |

`texlive-ja-textlint` のイメージが使っているのと同じ alpine のダイジェストに合わせることで Node 24.18.1 になる。

textlint 側の要求は `>=20.18.0`（`textlint-rule-terminology` は `>=20`）なので、Node 24 で問題ない。

## 2. ベースイメージのダイジェスト固定

これまでタグ（`alpine:3.22.0`）だけで指定していたため、**リポジトリに何の変更がなくても、先月ビルドした学生と今日ビルドした学生で中身が変わりうる**状態だった。`texlive-ja-textlint` 側は既にダイジェストまで固定している。

## 3. `npm install` → `npm ci`

`npm install` は `package.json` を基準に解決するため lock ファイルを超えたバージョンを引く余地がある。**全学生に同じ textlint を配ることが役目の devcontainer** では、lock ファイルが決定権を持つべきである。`texlive-ja-textlint` 側は既に `npm ci` を使っている。

## 検証

このリポジトリには devcontainer をビルドする CI が無いため、ローカルで実際にビルドして確認した。

```
docker build → 成功

node -v            → v24.18.1
npm -v             → 11.12.1
textlint --version → v15.7.1
```

実イメージで `index.html` に対して textlint を実行し、`ja-technical-writing` プリセットが期待どおり発火することを確認した。

## 補足: `index.html` の既存の textlint 指摘について

検証中に、テンプレートの `index.html` に textlint 指摘が 1 件あることに気付いた。

```
16:39  error  文末が"。"で終わっていません  ja-technical-writing/ja-no-mixed-period
```

該当は `<p class="author">理工学部 情報科学科 xxRSyyy 氏名</p>` で、著者名の行である。

**本 PR とも #99 のプリセット更新とも無関係**で、更新前の `preset-ja-technical-writing` v7.0.0 でも同じ 1 件が出ることを確認済み。ただし学生は最初から指摘 1 件の状態で始まり、氏名に置き換えても句点は付かないので指摘は残り続ける。著者名の行を lint 対象から外す設定を入れる余地がある。別件として扱う。
