### PR TITLE
ci: build the devcontainer image before merging changes to it

### DIFF
--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -1,0 +1,50 @@
+# DevContainer Build Check
+#
+# The devcontainer image is the environment every student writes in, and until
+# now nothing built it before merge. Build it whenever .devcontainer/ changes
+# and check that the toolchain inside actually works.
+
+name: DevContainer Build Check
+
+on:
+  pull_request:
+    paths:
+      - '.devcontainer/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and verify the image
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Build the image
+        run: docker build -t devcontainer-check .devcontainer
+
+      - name: Report the toolchain versions
+        run: |
+          docker run --rm devcontainer-check sh -c 'node -v; npm -v; textlint --version'
+
+      - name: Check that textlint reports what it is configured to report
+        run: |
+          # A version string only proves textlint starts. This fixture carries a
+          # violation the ja-technical-writing preset is configured to catch, so
+          # a preset or plugin that stops resolving fails the build here instead
+          # of silently linting nothing in every student's editor.
+          fixture="$(mktemp -d)"
+          cp .textlintrc "$fixture/"
+          printf '<html><body>\n<p>この文には句点がありません</p>\n</body></html>\n' \
+            > "$fixture/check.html"
+          output="$(docker run --rm -v "$fixture:/workdir" -w /workdir \
+            devcontainer-check sh -c 'textlint -f json check.html || true')"
+          printf '%s\n' "$output"
+          if ! printf '%s' "$output" | grep -q 'ja-technical-writing/ja-no-mixed-period'; then
+            echo "::error::textlint did not report ja-technical-writing/ja-no-mixed-period"
+            exit 1
+          fi

--- a/.github/workflows/devcontainer-build.yml
+++ b/.github/workflows/devcontainer-build.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     paths:
       - '.devcontainer/**'
+      # Changes to this check are verified by the check itself.
+      - '.github/workflows/devcontainer-build.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 問題

このリポジトリは `texlive-ja-textlint` のイメージを使わず **devcontainer を自前でビルド**しているが、**それを検証する CI が無い**。

`.devcontainer/Dockerfile` / `package.json` / `package-lock.json` が壊れた状態で merge されても、次に学生がコンテナを再ビルドするまで誰も気付かない。学生全員の執筆環境を決めるファイルとしては薄すぎる。

実際、直前の #101（ベースイメージを alpine 3.24.1 へ、`npm ci` 化）でもチェックは 1 つも走らなかった。ローカルでビルドして確認したが、毎回それに頼るのは属人的である。

## 追加する workflow

`.devcontainer/**` に変更があったときだけイメージをビルドし、中身が動くことを確認する。

```yaml
on:
  pull_request:
    paths:
      - '.devcontainer/**'
  workflow_dispatch:
```

ステップは 3 つ。

1. `docker build -t devcontainer-check .devcontainer`
2. `node -v` / `npm -v` / `textlint --version` を表示
3. **textlint が設定どおりに指摘を出すかを確認**

3 番目がこのジョブの要点である。バージョン文字列は textlint が起動することしか示さない。`ja-technical-writing` プリセットが捕まえるはずの違反を含む fixture を食わせ、**プリセットやプラグインの解決が壊れたらここで落ちる**ようにしてある。壊れたまま通ると、全学生のエディタで textlint が何も指摘しない状態になる。

これは `texlive-ja-textlint` が `tests/textlint/run-check.sh` で既に採っている考え方に倣ったもの。

```
# 同ファイルのコメントより
# Each fixture carries a violation it is built to trigger, so a rule
# that stops firing means its plugin or preset no longer resolves -- the
# class of breakage a bare `textlint --version` cannot see.
```

**fixture は workflow が実行時に書き出す**ので、学生がコピーするテンプレートには余分なファイルが増えない。

## 検証

workflow の各ステップをローカルでそのまま実行した。

```
[1] docker build            → OK
[2] node v24.18.1 / npm 11.12.1 / textlint v15.7.1
[3] ja-technical-writing/ja-no-mixed-period の発火を検出 → OK
```

`actionlint` / `yamllint`（このリポジトリの `.yamllint.yml` 準拠）とも指摘なし。

なお `.yamllint.yml` は `document-start: present: false` を指定しているため、先頭の `---` は付けていない。既存の `html-validation.yml` は `---` で始まっており設定に違反しているが、本 PR では触らない。

## 学生リポジトリへの継承について

テンプレートの workflow は学生リポジトリにコピーされる。この workflow も継承されるが、`paths: ['.devcontainer/**']` で絞ってあるため、学生が `.devcontainer/` を触らない限り発火しない。逆に学生が触った場合には正しく検証が走るので、そのまま残して問題ないと判断した。

## 補足

devcontainer に Dockerfile を持つのはエコシステム内でこのリポジトリだけである（他のテンプレートは `devcontainer.json` の `image:` で `texlive-ja-textlint` を参照する）。そのため `smkwlab/.github` の再利用ワークフローにはせず、このリポジトリ内に置いた。
